### PR TITLE
<filename>-images for file-in-folder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Create a directory with the same name of the current markdown file. Put the imag
 ```
 path
 ├── markdown-file-name.md
-├── markdown-file-name
-│   ├── image-md5-name.png
+├── markdown-file-name-images
+│   ├── image-md5-name-images.png
 │   └── ...
 └── ...
 ```
 
 ```
-![](markdown-file-name/image-md5-name.png)
+![](markdown-file-name-images/image-md5-name.png)
 ```

--- a/lib/markclip.coffee
+++ b/lib/markclip.coffee
@@ -47,7 +47,7 @@ module.exports = Markclip =
       imgFileDir = filePathObj.dir
       # IF:saveType: SAVE IN FOLDER, create it
       if saveType == SAVE_TYPE_FILE_IN_FOLDER
-        imgFileDir = path.join(imgFileDir, filePathObj.name)
+        imgFileDir = path.join(imgFileDir, filePathObj.name+'-images')
         mkdirp.sync(imgFileDir)
       # create file with md5 name
       imgFilePath = path.join(imgFileDir, md5(img.toDataUrl()).replace('=', '') + '.png')


### PR DESCRIPTION
use <file_name>-images folder instead of simply <file_name> folder for the SAVE_TYPE_FILE_IN_FOLDER option. 

This ends up being much less confusing for others who are trying to edit your markdown documents.

This change is very small, but I think has lots of potential. 

Please let me know if there are edge cases that I have completely overlooked in this case.
