### PR TITLE
Added Atom command and keymap for easier use

### DIFF
--- a/keymaps/markclip.cson
+++ b/keymaps/markclip.cson
@@ -1,0 +1,2 @@
+'atom-text-editor[data-grammar=\'source md\'], atom-text-editor[data-grammar=\'source gfm\'], atom-text-editor[data-grammar=\'text html basic\'], atom-text-editor[data-grammar=\'text md\'], atom-text-editor[data-grammar=\'text plain\'], atom-text-editor[data-grammar=\'text plain null-grammar\']':
+    "ctrl-v": "markclip:insert"

--- a/lib/markclip.coffee
+++ b/lib/markclip.coffee
@@ -23,10 +23,10 @@ module.exports = Markclip =
       enum: [SAVE_TYPE_BASE64, SAVE_TYPE_FILE, SAVE_TYPE_FILE_IN_FOLDER, SAVE_TYPE_CUSTOM_FILE]
     folderSpaceReplacer:
       type: 'string'
-      description: 'A charset to replace spaces in image floder name'
+      description: 'A charset to replace spaces in image folder name'
       default: SPACE_REPLACER
 
-  handleInsertEvent: () ->
+  handleInsertEvent: (e) ->
     textEditor = atom.workspace.getActiveTextEditor()
     # do nothing if there is no ActiveTextEditor
     return if !textEditor
@@ -34,7 +34,9 @@ module.exports = Markclip =
     # CHECK: do nothing if no image
     clipboard = require('clipboard')
     img = clipboard.readImage()
-    return if img.isEmpty()
+    if img.isEmpty()
+      e.abortKeyBinding()
+      return
 
     # CHECK: do nothing with unsaved file
     filePath = textEditor.getPath()
@@ -85,7 +87,7 @@ module.exports = Markclip =
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',
-      'markclip:insert': => @handleInsertEvent()
+      'markclip:insert': (e) => @handleInsertEvent(e)
 
     # atom.contextMenu.add {
     #   'atom-text-editor': [{

--- a/lib/markclip.coffee
+++ b/lib/markclip.coffee
@@ -88,6 +88,10 @@ module.exports = Markclip =
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',
       'markclip:insert': (e) => @handleInsertEvent(e)
+    @subscriptions.add atom.config.observe 'markclip.saveType', (val) ->
+      saveType = val
+    @subscriptions.add atom.config.observe 'markclip.folderSpaceReplacer', (val) ->
+      folderSpaceReplacer = val
 
     # atom.contextMenu.add {
     #   'atom-text-editor': [{


### PR DESCRIPTION
Instead of keymaps/markclip.cson, you could also allow the grammars to be set by the user in the config and then check to see if the editor grammar is in this set before handling an insert event. This is how `markdown-preview-plus` works. The (possible) downside is that the command is activated for every cmd/ctrl-z event which some people may not like.