### PR TITLE
Address deprecation of require('clipboard')

### DIFF
--- a/lib/markclip.coffee
+++ b/lib/markclip.coffee
@@ -40,7 +40,7 @@ module.exports = Markclip =
     return if !textEditor
 
     # CHECK: do nothing if no image
-    clipboard = require('clipboard')
+    clipboard = require('electron').clipboard
     img = clipboard.readImage()
     if img.isEmpty()
       e.abortKeyBinding()


### PR DESCRIPTION
Atom warns that `require('clipboard')` is depcrecated.